### PR TITLE
Remove requirement on Control Agent

### DIFF
--- a/pyisckea/daemons/ctrlagent.py
+++ b/pyisckea/daemons/ctrlagent.py
@@ -19,8 +19,8 @@ class CtrlAgent:
                 hooks=self.cached_config["Control-agent"]["hooks-libraries"]
             )
             self.api.hook_library[self.service] = self.hook_libraries
-        except Exception as e:
-            raise e
+        except Exception:
+            pass
 
     def refresh_cached_config(self):
         """Sets the cached_config variable


### PR DESCRIPTION
The requirement on the Control-Agent for Kea has been removed as of Kea 2.7.2 (https://kea.readthedocs.io/en/kea-2.7.9/arm/ctrl-channel.html#ctrl-channel-migration) and will be deprecated in a future Kea release (https://kea.readthedocs.io/en/kea-2.7.9/arm/agent.html#overview-of-the-kea-control-agent). As such, my current implementation of Kea doesn't have a Control Agent at all, but I would like to use this library, so this PR is removing the hard requirement on the CA to function (as it instead will cause a keyerror).

I would argue that this failure state should not silently ignore all errors like it is currently, and at minimum should likely print a warning. I would have added it except that there is no logging set up in this repository as of yet. 

There is some discussion that I would love to have and help implement on splitting out the various daemon classes, as each daemon has a different control port to access without a CA between them, as right now there is a hard dependency of the daemon classes on a central Kea class. I think having a `KeaControl` class (or something similar) that is split out from the central Kea class would make sense, such that `Kea` could have only one `KeaControl` class associated with it for all of it's associated Daemons, or you could create your own `KeaControl` for only certain Daemons.